### PR TITLE
Deploy Action.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-		- run: cargo --version
+		  run: cargo --version
 #    - uses: actions/checkout@v3
 #    - name: Build
 #      run: cargo build --verbose

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-		  run: cargo --version
+    - run: cargo --version
 #    - uses: actions/checkout@v3
 #    - name: Build
 #      run: cargo build --verbose

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,22 @@
+name: Deploy Rendered Site
+
+on: "push"
+#on:
+#  push:
+#    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  render-and-deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+		- run: cargo --version
+#    - uses: actions/checkout@v3
+#    - name: Build
+#      run: cargo build --verbose
+#    - name: Run tests
+#      run: cargo test --verbose

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -23,6 +23,8 @@ jobs:
     - run: mdbook build
     - name: Unignore docs
       run: sed -i 's|^docs/$||' .gitignore
+    - name: Disable jekyll
+      run: touch .nojekyll
     - uses: EndBug/add-and-commit@v9
       with:
         message: 'auto deploy'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: cargo --version
-#    - uses: actions/checkout@v3
-#    - name: Build
-#      run: cargo build --verbose
-#    - name: Run tests
-#      run: cargo test --verbose
+    - name: Setup mdBook
+      uses: peaceiris/actions-mdbook@v1
+      with:
+        mdbook-version: '0.4.10'
+        # mdbook-version: 'latest'
+
+    - run: mdbook build
+    - run: ls -laF

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,8 +17,7 @@ jobs:
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: '0.4.10'
-        # mdbook-version: 'latest'
-
+        mdbook-version: 'latest'
+    - uses: actions/checkout@v2
     - run: mdbook build
     - run: ls -laF

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,10 +1,8 @@
 name: Deploy Rendered Site
 
 on:
-  # FIXME: This should only trigger on merging to main.
   push:
-    # Make sure not to trigger on push to gh-pages!
-    branches: [ deploy-action ]
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,9 +1,10 @@
 name: Deploy Rendered Site
 
-on: "push"
-#on:
-#  push:
-#    branches: [ main ]
+on:
+  # FIXME: This should only trigger on merging to main.
+  push:
+    # Make sure not to trigger on push to gh-pages!
+    branches: [ deploy-action ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,4 +21,10 @@ jobs:
         mdbook-version: 'latest'
     - uses: actions/checkout@v2
     - run: mdbook build
-    - run: ls -laF
+    - uses: EndBug/add-and-commit@v9
+      with:
+        add: './docs'
+        message: 'auto deploy'
+        new_branch: gh-pages
+        pathspec_error_handling: exitAtEnd
+        push: true

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,9 +21,10 @@ jobs:
         mdbook-version: 'latest'
     - uses: actions/checkout@v2
     - run: mdbook build
+    - name: Unignore docs
+      run: sed -i 's|^docs/$||' .gitignore
     - uses: EndBug/add-and-commit@v9
       with:
-        add: './docs'
         message: 'auto deploy'
         new_branch: gh-pages
         pathspec_error_handling: exitAtEnd


### PR DESCRIPTION
Automatic github pages deploy of an mdbook:

- Triggers on a push to `main` (which occurs when a PR is merged).
- Renders with `mdbook`.
- Removes `./docs` from `.gitignore`. We only want to commit the rendered output on a special `gh-pages` deployment branch.
- Disabled `jekyll`, because we're using `mdbook`.
- Adds, commits, and pushes the result to `gh-pages`.
- The pages config is set to render the `gh-pages` branch `./docs` subdir.

Voilà!